### PR TITLE
Update to support 2nd poll 50ms after interrupt happens should multiple pins change during interrupt and not be detected.

### DIFF
--- a/src/pcf857x.ts
+++ b/src/pcf857x.ts
@@ -223,8 +223,12 @@ export abstract class PCF857x<PinNumber extends PCF8574.PinNumber | PCF8575.PinN
    * Internal function to handle a GPIO interrupt.
    */
   private _handleInterrupt (): void {
+    const self = this;
     // poll the current state and ignore any rejected promise
-    this._poll().catch(() => { /* nothing to do here */ });
+    self._poll().then(() => {
+        // poll a 2nd time a short time later in case interrupt did not report all changes.
+        setTimeout(() => {self._poll().catch(()=>{ /* nothing to do here */ })}, 50);
+    }).catch(()=>{ /* nothing to do here */ });
   }
 
   /**

--- a/src/pcf857x.ts
+++ b/src/pcf857x.ts
@@ -223,11 +223,10 @@ export abstract class PCF857x<PinNumber extends PCF8574.PinNumber | PCF8575.PinN
    * Internal function to handle a GPIO interrupt.
    */
   private _handleInterrupt (): void {
-    const self = this;
     // poll the current state and ignore any rejected promise
-    self._poll().then(() => {
-        // poll a 2nd time a short time later in case interrupt did not report all changes.
-        setTimeout(() => {self._poll().catch(()=>{ /* nothing to do here */ })}, 50);
+    this._poll().then(() => {
+      // poll a 2nd time a short time later in case interrupt did not report all changes.
+      setTimeout(() => {this._poll().catch(()=>{ /* nothing to do here */ })}, 50);
     }).catch(()=>{ /* nothing to do here */ });
   }
 


### PR DESCRIPTION
What I have seen is behavior such that if multiple inputs are activated and then deactivated, the interrupt handling routing might not detect the changes.  

As a workaround for this, I've added a 2nd poll 50ms after this change.  I will note that this change puts front and center a requirement for setTimeout to be in the project.  This should not likely be an issue as this project requires that NodeJS be present to run.  

For now, the default delay is 50ms and wondering if this should be configurable.