### PR TITLE
Fix for #59 - If interrupt occurs while doing the asynchronous read o…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pcf8574",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Control each pin of a PCF8574/PCF8574A/PCF8575 I2C port expander IC.",
   "keywords": [
     "pcf8574",

--- a/src/pcf857x.ts
+++ b/src/pcf857x.ts
@@ -231,7 +231,7 @@ export abstract class PCF857x<PinNumber extends PCF8574.PinNumber | PCF8575.PinN
       setTimeout(() => {
         this._poll().catch(() => {
           setTimeout(() => {
-            this._poll().catch(() => { })
+            this._poll().catch(() => { /* nothing to do here */ })
           }, pollDelay * 10)
         })
       }, pollDelay)


### PR DESCRIPTION
…f I2C, the poll will be rejected and the chip can be left in unrecoverable state

Bump version number
Provide tiered read using setTimeout